### PR TITLE
Add Docker-based integration tests for install scripts

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,32 @@
+name: Integration Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        container:
+          - ubuntu:22.04
+          - kalilinux/kali-rolling
+
+    container:
+      image: ${{ matrix.container }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          apt-get update || true
+          apt-get install -y bash git || true
+
+      - name: Run integration test
+        run: |
+          chmod +x tests/integration/ubuntu.test.sh
+          bash tests/integration/ubuntu.test.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update || true
-          apt-get install -y bash git || true
+          apt-get update
+          apt-get install -y sudo bash git
 
       - name: Run integration test
         run: |

--- a/tests/integration/ubuntu.test.sh
+++ b/tests/integration/ubuntu.test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Running Ubuntu integration test"
+
+
+bash scripts/linux/ubuntu.sh git
+
+
+if git --version > /dev/null 2>&1; then
+  echo "Git installed successfully"
+else
+  echo "Git installation failed"
+  exit 1
+fi


### PR DESCRIPTION
This PR introduces Docker-based integration tests that run the
installation scripts inside real container environments.

The test workflow:

1. Spin up container environments using Docker
2. Run the installation script (bash scripts/linux/ubuntu.sh git)
3. Verify installation by executing `git --version`
  
Files added:
 tests/integration/ubuntu.test.sh
 .github/workflows/integration.yml
