### PR TITLE
test: cover dry-run CLI flow

### DIFF
--- a/tests/dryRun.test.js
+++ b/tests/dryRun.test.js
@@ -1,0 +1,87 @@
+const toolsConfig = require("../config/tools.json");
+
+const passthrough = (value) => value;
+
+jest.mock("chalk", () => {
+  const bold = Object.assign(passthrough, {
+    cyan: passthrough,
+    green: passthrough,
+  });
+
+  return {
+    bold,
+    gray: passthrough,
+    green: passthrough,
+    blue: passthrough,
+    red: passthrough,
+    yellow: passthrough,
+    cyan: passthrough,
+    underline: passthrough,
+  };
+});
+
+jest.mock("../src/detectOS", () =>
+  jest.fn(() => ({
+    id: "windows",
+    label: "Windows",
+    scriptPath: "scripts/windows/install.ps1",
+    packageManager: "winget",
+  }))
+);
+
+jest.mock("../src/installer", () => ({
+  runInstaller: jest.fn(),
+}));
+
+jest.mock("../src/logger", () => ({
+  success: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  step: jest.fn(),
+}));
+
+describe("CLI --dry-run", () => {
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.argv = ["node", "index.js", "--dry-run", "--yes"];
+  });
+
+  afterAll(() => {
+    process.argv = originalArgv;
+  });
+
+  test("skips installation, prints dry-run output for each tool, and exits cleanly", async () => {
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    jest.isolateModules(() => {
+      require("../index.js");
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const { runInstaller } = require("../src/installer");
+    const dryRunLines = logSpy.mock.calls
+      .map((args) => args.join(" "))
+      .filter((line) => line.includes("[dry-run]"));
+
+    const expectedTools = toolsConfig.tools.filter(
+      (tool) => tool.os && tool.os.windows !== false
+    );
+
+    expect(runInstaller).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(dryRunLines).toHaveLength(expectedTools.length);
+    dryRunLines.forEach((line) => {
+      expect(line).toContain("[dry-run]");
+    });
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #44

## Summary
- add a CLI dry-run test for `--dry-run --yes`
- verify the installer path is skipped during dry-run
- assert `[dry-run]` output is printed for each supported tool on the mocked OS

## Validation
- `npx jest tests/dryRun.test.js` ?
- `npx jest --coverage` ?? fails due existing repo issues unrelated to this test:
  - `tests/scriptCoverage.test.js` fails because tool script coverage is already out of sync for `go`
  - `tests/installer.test.js` has an existing assertion failure around bash call args
  - global coverage thresholds are already not met on the current baseline
- `npx eslint src/ index.js tests/` ?? fails because ESLint cannot find a configuration file for the current command
