### PR TITLE
feat: add verbose installer output

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ program
   .version(VERSION)
   .option('-y, --yes',       'Skip prompts and install all tools automatically')
   .option('--dry-run',       'Show what would be installed without actually installing')
+  .option('--verbose',       'Show raw install output from package manager commands')
   .option('--list',          'List all available tools grouped by category and exit')
   .option('--category <cat>','Install only tools from a specific category')
   .parse(process.argv);
@@ -212,7 +213,7 @@ async function main() {
   }
 
   // ── Step 6: Install ───────────────────────────
-  await runInstaller(os, selectedToolNames);
+  await runInstaller(os, selectedToolNames, { verbose: options.verbose });
 
   // ── Step 7: Done ──────────────────────────────
   console.log('');

--- a/src/installer.js
+++ b/src/installer.js
@@ -20,9 +20,11 @@ const logger = require('./logger');
  *
  * @param {{ id: string, label: string, scriptPath: string }} osInfo - OS descriptor from detectOS()
  * @param {string[]} selectedTools - Array of tool names to install (e.g. ['git', 'nodejs'])
+ * @param {{ verbose?: boolean }} [options] - Installer behavior flags
  */
-async function runInstaller(osInfo, selectedTools) {
+async function runInstaller(osInfo, selectedTools, options = {}) {
   const scriptPath = path.join(__dirname, '..', osInfo.scriptPath);
+  const stdio = options.verbose ? 'inherit' : 'pipe';
 
   logger.info(`Running installer for ${chalk.bold(osInfo.label)}`);
   logger.info(`Package manager: ${chalk.bold(osInfo.packageManager)}\n`);
@@ -41,12 +43,12 @@ async function runInstaller(osInfo, selectedTools) {
           '-ExecutionPolicy', 'Bypass',
           '-File', scriptPath,
           '-Tool', tool,
-        ], { stdio: 'pipe' });
+        ], { stdio });
       } else {
         // macOS / Linux: run shell script
         // Ensure the script is executable first
         await execa('chmod', ['+x', scriptPath]);
-        await execa('bash', [scriptPath, tool], { stdio: 'pipe' });
+        await execa('bash', [scriptPath, tool], { stdio });
       }
 
       spinner.succeed(chalk.green(`Installed: ${chalk.bold(tool)}`));

--- a/tests/installer.test.js
+++ b/tests/installer.test.js
@@ -88,6 +88,18 @@ describe('runInstaller — Windows', () => {
     expect(args).toContain('-Tool');
     expect(args).toContain('nodejs');
   });
+
+  test('uses inherited stdio when verbose mode is enabled', async () => {
+    await runInstaller(windowsOS, ['git'], { verbose: true });
+    const psCalls = execa.mock.calls.filter((c) => c[0] === 'powershell');
+    expect(psCalls[0][2]).toMatchObject({ stdio: 'inherit' });
+  });
+
+  test('uses piped stdio by default', async () => {
+    await runInstaller(windowsOS, ['git']);
+    const psCalls = execa.mock.calls.filter((c) => c[0] === 'powershell');
+    expect(psCalls[0][2]).toMatchObject({ stdio: 'pipe' });
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #39

## Summary
- add a `--verbose` CLI flag
- pass verbose mode through to `runInstaller`
- switch installer commands to `stdio: 'inherit'` when verbose mode is enabled
- add focused installer tests for verbose vs default stdio behavior

## Validation
- `npx jest tests/installer.test.js -t "uses inherited stdio when verbose mode is enabled|uses piped stdio by default"` ?

## Notes
- full repo validation is still not green on the current baseline outside this change:
  - `npx jest --coverage` still fails because of existing failures in `tests/scriptCoverage.test.js`, `tests/installer.test.js`, and existing coverage-threshold misses
  - `npx eslint src/ index.js tests/` still fails because ESLint cannot find a configuration file for that command path in the checked repo state
